### PR TITLE
[FIX] website_sale_*: fix eslint warnings

### DIFF
--- a/website_sale_cart_expire/static/src/js/website_sale_cart_expire.js
+++ b/website_sale_cart_expire/static/src/js/website_sale_cart_expire.js
@@ -44,10 +44,11 @@ odoo.define("website_sale_cart_expire", (require) => {
          * @param {String|Date} expireDate
          */
         _setExpirationDate: function (expireDate) {
-            if (typeof expireDate === "string") {
-                expireDate = time.str_to_datetime(expireDate);
+            let formattedExpireDate = expireDate;
+            if (typeof formattedExpireDate === "string") {
+                formattedExpireDate = time.str_to_datetime(formattedExpireDate);
             }
-            this.expireDate = expireDate ? moment(expireDate) : false;
+            this.expireDate = formattedExpireDate ? moment(formattedExpireDate) : false;
         },
         /**
          * @returns {Number}
@@ -83,7 +84,10 @@ odoo.define("website_sale_cart_expire", (require) => {
             }
         },
         /**
-         * Updates the remaining time on the dom
+         * Updates the remaining time on the dom.
+         *
+         * @param {Number} remainingMs - Remaining time in milliseconds.
+         * @returns {void}
          */
         _renderTimer: function (remainingMs) {
             const remainingMsRounded = Math.ceil(remainingMs / 1000) * 1000;

--- a/website_sale_product_assortment/static/src/js/assortment_list_preview.js
+++ b/website_sale_product_assortment/static/src/js/assortment_list_preview.js
@@ -8,10 +8,10 @@ odoo.define("website_sale_product_assortment.assortment_preview", function (requ
         selector: "#products_grid",
 
         start: function () {
-            return $.when.apply($, [
+            return $.when(
                 this._super.apply(this, arguments),
-                this.render_assortments(),
-            ]);
+                this.render_assortments()
+            );
         },
         render_assortments: function () {
             const $products = $(".o_wsale_product_grid_wrapper");

--- a/website_sale_product_assortment/static/src/js/variant_mixin.js
+++ b/website_sale_product_assortment/static/src/js/variant_mixin.js
@@ -20,7 +20,7 @@ odoo.define("website_sale_product_assortment.VariantMixin", function (require) {
         const isMainProduct =
             combination.product_id &&
             ($parent.is(".js_main_product") || $parent.is(".main_product")) &&
-            combination.product_id === parseInt(product_id);
+            combination.product_id === parseInt(product_id, 10);
         if (!this.isWebsite || !isMainProduct) {
             return;
         }

--- a/website_sale_stock_list_preview/static/src/js/website_sale_stock_list_preview.js
+++ b/website_sale_stock_list_preview/static/src/js/website_sale_stock_list_preview.js
@@ -15,10 +15,7 @@ odoo.define("website_sale_stock_list_preview.shop_stock", function (require) {
             "click .btn.btn-primary.a-submit": "_onAddToCartClicked",
         },
         start: function () {
-            return $.when.apply($, [
-                this._super.apply(this, arguments),
-                this.render_stock(),
-            ]);
+            return $.when(this._super.apply(this, arguments), this.render_stock());
         },
         render_stock: function () {
             const $products = $(".o_wsale_product_grid_wrapper");


### PR DESCRIPTION
### Context:
Fix various ESLint warnings in website sale JS modules:

- website_sale_cart_expire
- website_sale_product_assortment
- website_sale_stock_list_preview

### Changes
- **website_sale_cart_expire**:
  - Fix parameter reassignment and missing JSDoc in [website_sale_cart_expire.js](cci:7://file:///home/khoi/code/oca/e-commerce/16.0/website_sale_cart_expire/static/src/js/website_sale_cart_expire.js:0:0-0:0).

- **website_sale_product_assortment**:
  - Add missing radix argument in `variant_mixin.js`.
  - Simplify `$.when.apply` usage in [assortment_list_preview.js](cci:7://file:///home/khoi/code/oca/e-commerce/16.0/website_sale_product_assortment/static/src/js/assortment_list_preview.js:0:0-0:0).

- **website_sale_stock_list_preview**:
  - Simplify `$.when.apply` usage in [website_sale_stock_list_preview.js](cci:7://file:///home/khoi/code/oca/e-commerce/16.0/website_sale_stock_list_preview/static/src/js/website_sale_stock_list_preview.js:0:0-0:0).